### PR TITLE
style: 💄 In resume preview page, sidebar is sticky now. ✅ Closes: #61

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,9 +80,11 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <Navbar />
-          {children}
-          <Footer />
+          <div className="flex flex-col min-h-[100vh]">
+            <Navbar />
+            <div className="grow">{children}</div>
+            <Footer />
+          </div>
         </ThemeProvider>
         <Analytics />
         <Toaster />

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -118,7 +118,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   };
 
   return (
-    <div className="w-64 p-4 space-y-4">
+    <div className="w-64 p-4 space-y-4 lg:sticky lg:top-0">
       <p className="text-lg font-semibold">Customize Display:</p>
       <div className="flex flex-col space-y-2">
         <label className="flex items-center space-x-2">


### PR DESCRIPTION
Now the sidebar in the resume preview page is sticky top.


**Screenshots**

Before
![image](https://github.com/ashutosh-rath02/git-re/assets/29487686/25414a32-6ab7-4e5c-b5db-81148310cc84)


After
![image](https://github.com/ashutosh-rath02/git-re/assets/29487686/2ed66406-5ab4-465d-b0c9-e42c72b8e694)

