### PR TITLE
Validation added for searching for a github username

### DIFF
--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -16,6 +16,13 @@ export default function Form() {
   const [isLoading, setIsLoading] = useState(false);
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
+
+    //Regex to match github username validation
+    const regex = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
+    if (!regex.test(username)) {
+      return;
+    }
+
     setIsLoading(true);
     setTimeout(() => {
       router.push(`/resume/${username}`);
@@ -42,7 +49,7 @@ export default function Form() {
         />
         <Button
           type="submit"
-          disabled={isLoading || username.trim() === ""}
+          disabled={isLoading}
           className="h-12 px-6 flex items-center justify-center"
         >
           {isLoading ? <div className="loader1"></div> : "Generate"}

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -3,6 +3,7 @@ import React, { FormEvent, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useRouter } from "next/navigation";
+import { toast, useToast } from "@/components/ui/use-toast";
 import axios from "axios";
 
 export default function Form() {
@@ -20,6 +21,11 @@ export default function Form() {
     //Regex to match github username validation
     const regex = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
     if (!regex.test(username)) {
+      toast({
+        title: "Error",
+        description: "Not a valid GitHub username.",
+        variant: "destructive",
+      });
       return;
     }
 


### PR DESCRIPTION
This PR is regarding issue #53.

# Description

I have used a regex that matches the actual github username validation criteria to fulfill our validation. Instead of indulging into an actual post request and return a 404, I've considered this approach to minimize extra operations and time consumption.

# Files Modified

components/Form.tsx : Added a regex and used an if statement.

## Working

The button would not send the post request as it should if the provided username seems to not follow the validation criteria. This is kept minimal until further guidance provided by the repository owner.

# [UPDATED]

# Description

Previously regex that matched the actual github username validation criteria to fulfill our validation. Now if the validation fails, a new toast appears regarding the failed validation. 

# Files Modified

components/Form.tsx : Added made a call to toast function.

## Working

Toast pops up for invalid username format as shown in the attached media.

![image](https://github.com/ashutosh-rath02/git-re/assets/95236968/9008d24e-96d2-4380-832c-95a169d676b2)
