### PR TITLE
fixed: testimonial cards text break in light mode

### DIFF
--- a/components/ui/infinite-moving-cards.tsx
+++ b/components/ui/infinite-moving-cards.tsx
@@ -99,15 +99,15 @@ export const InfiniteMovingCards = ({
                 aria-hidden="true"
                 className="user-select-none -z-1 pointer-events-none absolute -left-0.5 -top-0.5 h-[calc(100%_+_4px)] w-[calc(100%_+_4px)]"
               ></div>
-              <span className=" relative z-20 text-sm leading-[1.6] text-gray-100 font-normal">
+              <span className=" relative z-20 text-sm leading-[1.6] text-black dark:text-white font-normal">
                 {item.quote}
               </span>
               <div className="relative z-20 mt-6 flex flex-row items-center">
-                <span className="flex flex-col gap-1">
-                  <span className=" text-sm leading-[1.6] text-gray-400 font-normal">
+                <span className="flex flex-col gap-1/2">
+                  <span className=" text-sm leading-[1.6] text-primary font-semibold">
                     {item.name}
                   </span>
-                  <span className=" text-sm leading-[1.6] text-gray-400 font-normal">
+                  <span className=" text-sm leading-[1.6] text-secondaryText dark:text-gray-400 font-normal">
                     {item.title}
                   </span>
                 </span>


### PR DESCRIPTION
Fixed, #102 

### Before:
https://github.com/ashutosh-rath02/git-re/assets/65452005/44f17c87-2f20-4bed-87a1-9171f2e360b0

### After
https://github.com/ashutosh-rath02/git-re/assets/65452005/ceee1a2d-6724-4e9f-98ab-066691cbd980




