### PR TITLE
Feature Added : Copy sharable resume link to clipboard

### DIFF
--- a/components/CopyLinkBtn.tsx
+++ b/components/CopyLinkBtn.tsx
@@ -1,0 +1,42 @@
+import React, { ReactNode, useState } from "react";
+import { cn } from "@/lib/utils";
+import { toast } from "@/components/ui/use-toast";
+import { CheckCircledIcon, CheckIcon } from "@radix-ui/react-icons";
+
+interface CopyLinkProps {
+  url: string;
+  children: ReactNode;
+  className: string;
+}
+
+const CopyLinkBtn: React.FC<CopyLinkProps> = ({ url, children, className }) => {
+  const [isCopied, setCopied] = useState(false);
+
+  const toClipboard = () => {
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        toast({
+          title: "Link Copied Successfully!",
+          description: "",
+          variant: "default",
+        });
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {
+        toast({
+          title: "Error",
+          description: "Error Copying Link",
+          variant: "destructive",
+        });
+      });
+  };
+  return (
+    <button onClick={toClipboard} className={cn(className, "bg-white p-3")}>
+      {isCopied === true ? <CheckCircledIcon /> : children}
+    </button>
+  );
+};
+
+export default CopyLinkBtn;

--- a/components/ShareBtn.tsx
+++ b/components/ShareBtn.tsx
@@ -14,8 +14,9 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Share1Icon } from "@radix-ui/react-icons";
+import { CopyIcon, Share1Icon } from "@radix-ui/react-icons";
 import { Button } from "./ui/button";
+import CopyLinkBtn from "./CopyLinkBtn";
 
 const ShareBtn = ({ username }: { username: string }) => {
   return (
@@ -50,6 +51,12 @@ const ShareBtn = ({ username }: { username: string }) => {
             >
               <TwitterIcon className="rounded-full" size={40} />
             </TwitterShareButton>
+            <CopyLinkBtn
+              className="rounded-full "
+              url={`${window.origin}/resume/${username}`}
+            >
+              <CopyIcon className="text-black" />
+            </CopyLinkBtn>
           </DialogDescription>
         </DialogHeader>
       </DialogContent>


### PR DESCRIPTION
## Related Issue
This issue has reference to Issue #176 

## Description
The feature enables the users to copy their sharable link to resume to share on other platforms.
### Files Created: *components/CopyLinkBtn.tsx* 
### Files Modified: *components/ShareBtn.tsx*

## Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![image](https://github.com/ashutosh-rath02/git-re/assets/95236968/cc557e07-0e08-4f84-9405-2b2c8b72b37a)



## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
