### PR TITLE
solves User is rate-limited by GitHub (issue324)

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -64,7 +64,7 @@ export async function POST(request: NextRequest) {
         username: response.data.login || "",
       };
 
-      if (!userData.name) {
+      if (!userData.username) {
         console.log("Data is NULL. User is rate-limited by GitHub");
         return new Response(
           "Data is NULL. You are rate-limited, please try again later.",


### PR DESCRIPTION
## Related Issue
Encountering the "Data is NULL. User is rate-limited by GitHub" error for some usernames.

## Description
#324 

## Type of PR

- [ X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![image](https://github.com/ashutosh-rath02/git-re/assets/122457803/1dc3a7b9-3dc9-4f1e-ac92-e8d9a08a33c0)
![image](https://github.com/ashutosh-rath02/git-re/assets/122457803/710c654b-9d5f-4888-aaeb-ecc26fc33e3b)


## Checklist:
- [X ] I have performed a self-review of my code
- [X ] I have read and followed the Contribution Guidelines.
- [X ] I have tested the changes thoroughly before submitting this pull request.
- [ X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
The current code checks if userData.name is null or empty to determine if the user is rate-limited. However, this might not be the most reliable method, as some users might genuinely have no name set on their GitHub profile. So it should be changed to userData.username.
