### PR TITLE
fixed: The "images.domains" configuration is deprecated. Please use "images.remotePatterns" configuration instead.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,24 +3,9 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'http',
-        hostname: 'localhost',
-      },
-      {
-        protocol: 'https',
-        hostname: 'res.cloudinary.com',
-      },
-      {
         protocol: 'https',
         hostname: 'avatars.githubusercontent.com',
-      },
-      {
-        protocol: 'https',
-        hostname: 'github-readme-stats.vercel.app',
-      },
-      {
-        protocol: 'https',
-        hostname: 'ghchart.rshah.org',
+        pathname: '/u/*',
       },
     ],
   },

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,27 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: [
-      "localhost",
-      "res.cloudinary.com",
-      "avatars.githubusercontent.com",
-      "github-readme-stats.vercel.app",
-      "ghchart.rshah.org",
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+      },
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'github-readme-stats.vercel.app',
+      },
+      {
+        protocol: 'https',
+        hostname: 'ghchart.rshah.org',
+      },
     ],
   },
 };


### PR DESCRIPTION
Fixes #328 