### PR TITLE
Display&Update the repos's live star count(#438)

### DIFF
--- a/components/GitHubStarCount.tsx
+++ b/components/GitHubStarCount.tsx
@@ -1,0 +1,57 @@
+// components/GitHubStarCount.tsx
+"use client";
+
+import React, { useEffect, useState } from 'react';
+
+interface GitHubStarCountProps {
+  repoUrl: string;
+}
+
+const GitHubStarCount: React.FC<GitHubStarCountProps> = ({ repoUrl }) => {
+  const [stars, setStars] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStarCount = async () => {
+      try {
+        // Ensure the repo URL is in the format /owner/repo
+        const repoPath = repoUrl.replace('https://github.com', '');
+        const response = await fetch(`https://api.github.com/repos${repoPath}`, {
+            headers: {
+              'Authorization': `token ${process.env.NEXT_PUBLIC_GITHUB_TOKEN}` // Replace YOUR_GITHUB_TOKEN with a GitHub Personal Access Token
+            }
+          });
+          
+        
+        
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        const data = await response.json();
+        if (data && typeof data.stargazers_count === 'number') {
+          setStars(data.stargazers_count);
+        } else {
+          throw new Error('Invalid data format');
+        }
+      } catch (error) {
+        console.error('Error fetching star count:', error);
+        setError('error');
+      }
+    };
+
+    fetchStarCount();
+  }, [repoUrl]);
+
+  if (error) {
+    return <span>{error}</span>;
+  }
+
+  return (
+    <span>
+      {stars !== null ? `${stars}` : '0'}
+    </span>
+  );
+};
+
+export default GitHubStarCount;

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "./ui/button";
 import { ModeToggle } from "./shared/ToggleBg";
 import { GitHubLogoIcon } from "@radix-ui/react-icons";
+import GitHubStarCount from './GitHubStarCount'; 
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
@@ -64,8 +65,9 @@ export default function Footer() {
           rel="noopener noreferrer"
           className="w-48 mt-8 rounded-sm py-4 text-base font-semibold dark:text-white flex flex-row items-center bg-primary text-white justify-center"
         >
-          <IconStarFilled className="mr-2" />
-          Star on GitHub
+         
+          <GitHubStarCount repoUrl="https://github.com/ashutosh-rath02/git-re" /> 
+          <p className="pl-2 pr-2">  Stars on </p> <GitHubLogoIcon width="22" height="22" />
         </Link>
       </div>
       {/* LINKS */}


### PR DESCRIPTION
## Related Issue
None

## Description
### Footer Component

The `Footer` component renders the footer section of a webpage. It includes:

- **GitHub Star Count**: Dynamically fetches and displays the star count for a specified GitHub repository (`git-re`) using the `GitHubStarCount` component.

### GitHubStarCount Component

The `GitHubStarCount` component fetches and displays the star count from a GitHub repository.

- **Props**: 
  - `repoUrl`: The URL of the GitHub repository.

- **State Management**:
  - `stars`: Stores the star count.
  - `error`: Stores any error messages.

- **Effect Hook**: 
  - Fetches the star count when the component mounts or `repoUrl` changes using the GitHub API.
  - Displays the star count or an error message if the fetch fails.

## Type of PR
- [ ] Feature enhancement

## Screenshots / videos (if applicable)

 **Before **: 
![Screenshot_2024-08-08-12-17-26-203_com android chrome](https://github.com/user-attachments/assets/9d0dcb27-0df0-4a3c-9e80-b49b31c26299)

 **After **: 
![Screenshot_2024-08-07-22-54-41-650_com whatsapp](https://github.com/user-attachments/assets/6126b76c-b1dc-42b1-bfa0-d84fb08730bb)



## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.