### PR TITLE
Added Padding Top to the LeaderBoard page

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -72,7 +72,7 @@ export default function Leaderboard() {
 
   return (
     <>
-      <div className="max-w-screen-lg mx-auto px-4 lg:px-8">
+      <div className="max-w-screen-lg mx-auto px-4 lg:px-8 pt-12">
         <div className="justify-between items-center mb-20 mt-10 grid grid-cols-1 sm:grid-cols-2 gap-4">
           <h1 className="text-2xl font-semibold">Leaderboard</h1>
           <div className="flex">


### PR DESCRIPTION
Signed-off-by: Chandan-6 <khamitkarsaichandan1035@gmail.com>

* Added pt-12 -> path : app/leaderboard/page.tsx
* This makes the Title + Search Bar visible.
* Now user can know what they are typing in the search bar.

## Related Issue
Fixes #451 

## Description
- Added pt-12 ( padding-top : 3rem )

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/c3ed0262-474f-4a3d-aeb4-935cb6827ead


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

